### PR TITLE
Implement user account management

### DIFF
--- a/client/src/main/java/com/bibengine/web/AccountWebController.java
+++ b/client/src/main/java/com/bibengine/web/AccountWebController.java
@@ -1,0 +1,77 @@
+package com.bibengine.web;
+
+import jakarta.servlet.http.HttpSession;
+import org.springframework.http.*;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+/**
+ * Proste widoki do zarządzania kontem użytkownika
+ */
+@Controller
+@RequestMapping("/account")
+public class AccountWebController {
+    private final RestTemplate rest = new RestTemplate();
+
+    private HttpHeaders authHeaders(HttpSession session) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        Object token = session.getAttribute("token");
+        if (token != null) {
+            headers.set(HttpHeaders.AUTHORIZATION, "Bearer " + token);
+        }
+        return headers;
+    }
+
+    private HttpEntity<?> authEntity(HttpSession session) {
+        return new HttpEntity<>(authHeaders(session));
+    }
+
+    @GetMapping
+    public String account(Model model, @RequestParam(required = false) String error) {
+        if (error != null) model.addAttribute("error", error);
+        return "account";
+    }
+
+    @PostMapping("/update")
+    public String update(@RequestParam String username,
+                         @RequestParam String email,
+                         HttpSession session,
+                         org.springframework.web.servlet.mvc.support.RedirectAttributes ra) {
+        Map<String, String> body = Map.of("username", username, "email", email);
+        HttpEntity<Map<String, String>> entity = new HttpEntity<>(body, authHeaders(session));
+        try {
+            rest.exchange("http://localhost:5100/api/account", HttpMethod.PUT, entity, String.class);
+        } catch (Exception ex) {
+            ra.addFlashAttribute("error", "Nie udało się zaktualizować profilu");
+        }
+        return "redirect:/account";
+    }
+
+    @PostMapping("/password")
+    public String changePassword(@RequestParam String password,
+                                 HttpSession session,
+                                 org.springframework.web.servlet.mvc.support.RedirectAttributes ra) {
+        Map<String, String> body = Map.of("password", password);
+        HttpEntity<Map<String, String>> entity = new HttpEntity<>(body, authHeaders(session));
+        try {
+            rest.exchange("http://localhost:5100/api/account/password", HttpMethod.PUT, entity, String.class);
+        } catch (Exception ex) {
+            ra.addFlashAttribute("error", "Nie udało się zmienić hasła");
+        }
+        return "redirect:/account";
+    }
+
+    @PostMapping("/delete")
+    public String delete(HttpSession session) {
+        try {
+            rest.exchange("http://localhost:5100/api/account", HttpMethod.DELETE, authEntity(session), String.class);
+        } catch (Exception ignored) {}
+        session.invalidate();
+        return "redirect:/";
+    }
+}

--- a/client/src/main/resources/templates/account.html
+++ b/client/src/main/resources/templates/account.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Moje konto - BibEngine</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" />
+</head>
+<body class="container">
+<h1>Moje konto</h1>
+<div class="alert alert-danger" th:if="${error}" th:text="${error}"></div>
+<h2>Dane użytkownika</h2>
+<form method="post" th:action="@{/account/update}">
+    <div class="mb-3">
+        <label class="form-label">Login</label>
+        <input class="form-control" name="username" required>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Email</label>
+        <input class="form-control" name="email" type="email" required>
+    </div>
+    <button class="btn btn-primary">Zapisz</button>
+</form>
+<h2 class="mt-4">Zmiana hasła</h2>
+<form method="post" th:action="@{/account/password}">
+    <div class="mb-3">
+        <label class="form-label">Nowe hasło</label>
+        <input class="form-control" name="password" type="password" required minlength="7">
+    </div>
+    <button class="btn btn-secondary">Zmień hasło</button>
+</form>
+<h2 class="mt-4 text-danger">Usuń konto</h2>
+<form method="post" th:action="@{/account/delete}">
+    <p>Usunięcie konta spowoduje skasowanie wszystkich Twoich bibliografii.</p>
+    <button class="btn btn-danger">Usuń konto</button>
+</form>
+<p class="mt-3"><a th:href="@{/bibliography}" class="btn btn-link">Powrót</a></p>
+</body>
+</html>

--- a/client/src/main/resources/templates/bibliography.html
+++ b/client/src/main/resources/templates/bibliography.html
@@ -7,6 +7,7 @@
 </head>
 <body class="container">
 <h1>Moje bibliografie</h1>
+<p><a th:href="@{/account}" class="btn btn-link">Moje konto</a></p>
 <div class="alert alert-danger" th:if="${error}" th:text="${error}"></div>
 <table class="table">
     <thead>

--- a/client/src/main/resources/templates/entries.html
+++ b/client/src/main/resources/templates/entries.html
@@ -7,6 +7,7 @@
 </head>
 <body class="container">
 <h1 th:text="${bibliography.name}">Bibliografia</h1>
+<p><a th:href="@{/account}" class="btn btn-link">Moje konto</a></p>
 <p th:text="${bibliography.comment}"></p>
 <div class="alert alert-danger" th:if="${error}" th:text="${error}"></div>
 <table class="table">

--- a/client/src/main/resources/templates/index.html
+++ b/client/src/main/resources/templates/index.html
@@ -11,6 +11,7 @@
 <a th:href="@{/login}" class="btn btn-primary me-2">Logowanie</a>
 <a th:href="@{/register}" class="btn btn-secondary me-2">Rejestracja</a>
 <a th:href="@{/bibliography}" class="btn btn-success me-2">Moje bibliografie</a>
+<a th:href="@{/account}" class="btn btn-secondary me-2">Moje konto</a>
 <a th:href="@{/regulamin}" class="btn btn-link">Regulamin</a>
 <a th:href="@{/docs}" class="btn btn-link">Dokumentacja</a>
 </body>

--- a/server/src/main/java/com/bibengine/bibliography/BibEntry.java
+++ b/server/src/main/java/com/bibengine/bibliography/BibEntry.java
@@ -1,5 +1,6 @@
 package com.bibengine.bibliography;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 
 /**
@@ -25,6 +26,7 @@ public class BibEntry {
     private String type; // np. article, book itd.
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JsonIgnore
     private Bibliography bibliography;
 
     public Long getId() { return id; }

--- a/server/src/main/java/com/bibengine/bibliography/Bibliography.java
+++ b/server/src/main/java/com/bibengine/bibliography/Bibliography.java
@@ -1,6 +1,7 @@
 package com.bibengine.bibliography;
 
 import com.bibengine.user.User;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
@@ -17,9 +18,11 @@ public class Bibliography {
     private String comment;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JsonIgnore
     private User owner;
 
     @OneToMany(mappedBy = "bibliography", cascade = CascadeType.ALL, orphanRemoval = true)
+    @JsonIgnore
     private List<BibEntry> entries = new ArrayList<>();
 
     public Long getId() { return id; }

--- a/server/src/main/java/com/bibengine/bibliography/BibliographyService.java
+++ b/server/src/main/java/com/bibengine/bibliography/BibliographyService.java
@@ -27,7 +27,13 @@ public class BibliographyService {
         return bibliographyRepository.findByOwner(user);
     }
 
-    public Optional<Bibliography> get(Long id) { return bibliographyRepository.findById(id); }
+    @Transactional(readOnly = true)
+    public Optional<Bibliography> get(Long id) {
+        return bibliographyRepository.findById(id).map(b -> {
+            b.getEntries().size(); // inicjalizacja wpisów w ramach transakcji
+            return b;
+        });
+    }
 
     @Transactional
     public Bibliography create(String username, Bibliography b) {
@@ -45,6 +51,7 @@ public class BibliographyService {
                 .stream().filter(e -> e.getBibliography().getOwner().equals(user)).toList();
     }
 
+    @Transactional
     public BibEntry addEntry(Long bibliographyId, BibEntry entry) {
         Bibliography b = bibliographyRepository.findById(bibliographyId).orElseThrow();
         entry.setBibliography(b);

--- a/server/src/main/java/com/bibengine/user/AccountController.java
+++ b/server/src/main/java/com/bibengine/user/AccountController.java
@@ -1,0 +1,36 @@
+package com.bibengine.user;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+/**
+ * Kontroler pozwalający użytkownikowi zarządzać swoim kontem
+ */
+@RestController
+@RequestMapping("/api/account")
+public class AccountController {
+    private final UserService userService;
+
+    public AccountController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @PutMapping("/password")
+    public void changePassword(Authentication auth, @RequestBody Map<String, String> body) {
+        userService.changePassword(auth.getName(), body.get("password"));
+    }
+
+    @PutMapping
+    public User update(Authentication auth, @RequestBody Map<String, String> body) {
+        String username = body.get("username");
+        String email = body.get("email");
+        return userService.updateProfile(auth.getName(), username, email);
+    }
+
+    @DeleteMapping
+    public void delete(Authentication auth) {
+        userService.deleteAccount(auth.getName());
+    }
+}

--- a/server/src/main/java/com/bibengine/user/UserService.java
+++ b/server/src/main/java/com/bibengine/user/UserService.java
@@ -1,15 +1,19 @@
 package com.bibengine.user;
 
+import com.bibengine.bibliography.BibliographyRepository;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class UserService {
     private final UserRepository userRepository;
+    private final BibliographyRepository bibliographyRepository;
     private final BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
 
-    public UserService(UserRepository userRepository) {
+    public UserService(UserRepository userRepository, BibliographyRepository bibliographyRepository) {
         this.userRepository = userRepository;
+        this.bibliographyRepository = bibliographyRepository;
     }
 
     // prosta rejestracja użytkownika
@@ -32,5 +36,44 @@ public class UserService {
         User user = userRepository.findByUsername(username);
         if (user == null) return false;
         return passwordEncoder.matches(password, user.getPassword());
+    }
+
+    /** Zmiana hasła bieżącego użytkownika */
+    @Transactional
+    public void changePassword(String username, String newPassword) {
+        if (newPassword == null || newPassword.length() < 7) {
+            throw new IllegalArgumentException("Hasło musi mieć min 7 znaków");
+        }
+        User user = userRepository.findByUsername(username);
+        if (user == null) throw new IllegalArgumentException("Użytkownik nie istnieje");
+        user.setPassword(passwordEncoder.encode(newPassword));
+        userRepository.save(user);
+    }
+
+    /** Aktualizacja loginu lub emaila */
+    @Transactional
+    public User updateProfile(String username, String newUsername, String newEmail) {
+        User user = userRepository.findByUsername(username);
+        if (user == null) throw new IllegalArgumentException("Użytkownik nie istnieje");
+        if (newUsername != null && !newUsername.equals(username)) {
+            if (userRepository.existsByUsername(newUsername)) {
+                throw new IllegalArgumentException("Użytkownik o tym loginie już istnieje");
+            }
+            user.setUsername(newUsername);
+        }
+        if (newEmail != null) {
+            user.setEmail(newEmail);
+        }
+        return userRepository.save(user);
+    }
+
+    /** Usunięcie konta wraz z bibliografiami */
+    @Transactional
+    public void deleteAccount(String username) {
+        User user = userRepository.findByUsername(username);
+        if (user == null) return;
+        var bibliographies = bibliographyRepository.findByOwner(user);
+        bibliographyRepository.deleteAll(bibliographies);
+        userRepository.delete(user);
     }
 }


### PR DESCRIPTION
## Summary
- create account management REST controller and service logic
- allow updating username/email and password
- support deleting an account with all bibliographies
- add web controller and page for account settings
- link account page in templates

## Testing
- `mvn -q -pl server test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6843eae97310832c97bf594f2ab2b59b