### PR TITLE
Add search, sorting and BibTeX cleanup

### DIFF
--- a/client/src/main/java/com/bibengine/web/BibTexWebController.java
+++ b/client/src/main/java/com/bibengine/web/BibTexWebController.java
@@ -1,0 +1,52 @@
+package com.bibengine.web;
+
+import jakarta.servlet.http.HttpSession;
+import org.springframework.http.*;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Map;
+
+/**
+ * Widok czyszczenia pliku BibTeX i generowania \thebibliography.
+ */
+@Controller
+public class BibTexWebController {
+    private final RestTemplate rest = new RestTemplate();
+
+    private HttpEntity<?> authEntity(HttpSession session, HttpEntity.BodyBuilder builder) {
+        HttpHeaders headers = new HttpHeaders();
+        Object token = session.getAttribute("token");
+        if (token != null) headers.set(HttpHeaders.AUTHORIZATION, "Bearer " + token);
+        return builder.headers(headers).build();
+    }
+
+    @GetMapping("/bibtex-clean")
+    public String form() { return "bibtex_clean"; }
+
+    @PostMapping("/bibtex-clean")
+    public String handle(@RequestParam("file") MultipartFile file, Model model, HttpSession session) {
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.MULTIPART_FORM_DATA);
+            HttpEntity<MultipartFile> entity = new HttpEntity<>(file, headers);
+            ResponseEntity<Map> resp = rest.exchange(
+                    "http://localhost:5100/api/bibtex/clean",
+                    HttpMethod.POST,
+                    entity,
+                    Map.class);
+            if (resp.getStatusCode().is2xxSuccessful() && resp.getBody() != null) {
+                model.addAttribute("bibtex", resp.getBody().get("bibtex"));
+                model.addAttribute("latex", resp.getBody().get("latex"));
+            }
+        } catch (Exception ex) {
+            model.addAttribute("error", "Nie udało się przetworzyć pliku");
+        }
+        return "bibtex_clean";
+    }
+}

--- a/client/src/main/java/com/bibengine/web/BibliographyWebController.java
+++ b/client/src/main/java/com/bibengine/web/BibliographyWebController.java
@@ -38,13 +38,22 @@ public class BibliographyWebController {
 
     // Lista baz bibliograficznych
     @GetMapping
-    public String list(Model model, HttpSession session) {
+    public String list(@RequestParam(required = false) String q,
+                       @RequestParam(required = false) String sort,
+                       @RequestParam(required = false) String dir,
+                       Model model, HttpSession session) {
         if (session.getAttribute("token") == null) {
             return "redirect:/login";
         }
         try {
+            String url = "http://localhost:5100/api/bibliography";
+            List<String> params = new ArrayList<>();
+            if (q != null) params.add("q=" + q);
+            if (sort != null) params.add("sort=" + sort);
+            if (dir != null) params.add("dir=" + dir);
+            if (!params.isEmpty()) url += "?" + String.join("&", params);
             ResponseEntity<BibliographyDto[]> resp = rest.exchange(
-                    "http://localhost:5100/api/bibliography",
+                    url,
                     HttpMethod.GET,
                     authEntity(session),
                     BibliographyDto[].class
@@ -82,7 +91,11 @@ public class BibliographyWebController {
 
     // Wyświetlanie wpisów konkretnej bazy
     @GetMapping("/{id}")
-    public String entries(@PathVariable Long id, Model model, HttpSession session) {
+    public String entries(@PathVariable Long id,
+                          @RequestParam(required = false) String q,
+                          @RequestParam(required = false) String sort,
+                          @RequestParam(required = false) String dir,
+                          Model model, HttpSession session) {
         if (session.getAttribute("token") == null) {
             return "redirect:/login";
         }
@@ -98,8 +111,14 @@ public class BibliographyWebController {
                     if (b.id().equals(id)) { bibliography = b; break; }
                 }
             }
+            String url = "http://localhost:5100/api/bibliography/" + id + "/entries";
+            List<String> params = new ArrayList<>();
+            if (q != null) params.add("q=" + q);
+            if (sort != null) params.add("sort=" + sort);
+            if (dir != null) params.add("dir=" + dir);
+            if (!params.isEmpty()) url += "?" + String.join("&", params);
             ResponseEntity<BibEntryDto[]> resp = rest.exchange(
-                    "http://localhost:5100/api/bibliography/" + id + "/entries",
+                    url,
                     HttpMethod.GET,
                     authEntity(session),
                     BibEntryDto[].class);

--- a/client/src/main/resources/templates/bibliography.html
+++ b/client/src/main/resources/templates/bibliography.html
@@ -9,14 +9,36 @@
 <h1>Moje bibliografie</h1>
 <p><a th:href="@{/account}" class="btn btn-link">Moje konto</a></p>
 <div class="alert alert-danger" th:if="${error}" th:text="${error}"></div>
+<form class="row mb-3" method="get" th:action="@{/bibliography}">
+    <div class="col-auto">
+        <input class="form-control" name="q" placeholder="Szukaj" th:value="${param.q}">
+    </div>
+    <div class="col-auto">
+        <select class="form-select" name="sort">
+            <option th:selected="${param.sort=='name'}" value="name">Nazwa</option>
+            <option th:selected="${param.sort=='comment'}" value="comment">Notatka</option>
+        </select>
+    </div>
+    <div class="col-auto">
+        <select class="form-select" name="dir">
+            <option th:selected="${param.dir=='asc'}" value="asc">Rosnąco</option>
+            <option th:selected="${param.dir=='desc'}" value="desc">Malejąco</option>
+        </select>
+    </div>
+    <div class="col-auto">
+        <button class="btn btn-secondary">Filtruj</button>
+    </div>
+</form>
+
 <table class="table">
     <thead>
-    <tr><th>Nazwa</th><th>Notatka</th><th></th></tr>
+    <tr><th>Nazwa</th><th>Notatka</th><th>Ilość wpisów</th><th></th></tr>
     </thead>
     <tbody>
     <tr th:each="b : ${bibliographies}">
         <td th:text="${b.name}"></td>
         <td th:text="${b.comment}"></td>
+        <td th:text="${b.entryCount}"></td>
         <td><a th:href="@{'/bibliography/' + ${b.id}}" class="btn btn-sm btn-primary">Wpisy</a></td>
     </tr>
     </tbody>

--- a/client/src/main/resources/templates/bibtex_clean.html
+++ b/client/src/main/resources/templates/bibtex_clean.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Czyszczenie BibTeX - BibEngine</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" />
+</head>
+<body class="container">
+<h1>Czyszczenie BibTeX</h1>
+<div class="alert alert-danger" th:if="${error}" th:text="${error}"></div>
+<form method="post" enctype="multipart/form-data" th:action="@{/bibtex-clean}">
+    <div class="mb-3">
+        <label class="form-label">Plik BibTeX</label>
+        <input type="file" name="file" class="form-control" required>
+    </div>
+    <button class="btn btn-primary">Wyślij</button>
+</form>
+<div th:if="${bibtex}">
+    <h2>Wyczyszczony BibTeX</h2>
+    <pre th:text="${bibtex}"></pre>
+    <h2>LaTeX \thebibliography</h2>
+    <pre th:text="${latex}"></pre>
+</div>
+<p><a th:href="@{/}" class="btn btn-link">Powrót</a></p>
+</body>
+</html>

--- a/client/src/main/resources/templates/entries.html
+++ b/client/src/main/resources/templates/entries.html
@@ -10,6 +10,26 @@
 <p><a th:href="@{/account}" class="btn btn-link">Moje konto</a></p>
 <p th:text="${bibliography.comment}"></p>
 <div class="alert alert-danger" th:if="${error}" th:text="${error}"></div>
+<form class="row mb-3" method="get" th:action="@{'/bibliography/' + ${bibliography.id}}">
+    <div class="col-auto">
+        <input class="form-control" name="q" placeholder="Szukaj" th:value="${param.q}">
+    </div>
+    <div class="col-auto">
+        <select class="form-select" name="sort">
+            <option th:selected="${param.sort=='title'}" value="title">Tytuł</option>
+            <option th:selected="${param.sort=='authors'}" value="authors">Autorzy</option>
+            <option th:selected="${param.sort=='year'}" value="year">Rok</option>
+        </select>
+    </div>
+    <div class="col-auto">
+        <select class="form-select" name="dir">
+            <option th:selected="${param.dir=='asc'}" value="asc">Rosnąco</option>
+            <option th:selected="${param.dir=='desc'}" value="desc">Malejąco</option>
+        </select>
+    </div>
+    <div class="col-auto"><button class="btn btn-secondary">Filtruj</button></div>
+</form>
+
 <table class="table">
     <thead>
     <tr><th>Tytuł</th><th>Autorzy</th><th>Rok</th><th>Journal</th><th>DOI</th></tr>

--- a/client/src/main/resources/templates/index.html
+++ b/client/src/main/resources/templates/index.html
@@ -12,6 +12,7 @@
 <a th:href="@{/register}" class="btn btn-secondary me-2">Rejestracja</a>
 <a th:href="@{/bibliography}" class="btn btn-success me-2">Moje bibliografie</a>
 <a th:href="@{/account}" class="btn btn-secondary me-2">Moje konto</a>
+<a th:href="@{/bibtex-clean}" class="btn btn-secondary me-2">Czyszczenie BibTeX</a>
 <a th:href="@{/regulamin}" class="btn btn-link">Regulamin</a>
 <a th:href="@{/docs}" class="btn btn-link">Dokumentacja</a>
 </body>

--- a/server/src/main/java/com/bibengine/bibliography/BibEntryRepository.java
+++ b/server/src/main/java/com/bibengine/bibliography/BibEntryRepository.java
@@ -4,8 +4,14 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
+import org.springframework.data.domain.Sort;
+
 public interface BibEntryRepository extends JpaRepository<BibEntry, Long> {
     List<BibEntry> findByBibliographyOwnerId(Long ownerId);
 
     List<BibEntry> findByTitleContainingIgnoreCaseOrAuthorsContainingIgnoreCase(String title, String authors);
+
+    List<BibEntry> findByBibliographyId(Long bibliographyId, Sort sort);
+
+    long countByBibliographyId(Long bibliographyId);
 }

--- a/server/src/main/java/com/bibengine/bibliography/BibTexCleanService.java
+++ b/server/src/main/java/com/bibengine/bibliography/BibTexCleanService.java
@@ -1,0 +1,81 @@
+package com.bibengine.bibliography;
+
+import org.springframework.stereotype.Service;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+/**
+ * Proste czyszczenie pliku BibTeX. Zachowuje tylko pola wymagane
+ * dla podstawowych typów wpisów w APA (article oraz book).
+ */
+@Service
+public class BibTexCleanService {
+
+    /**
+     * Parsuje tekst BibTeX do listy wpisów BibEntry.
+     */
+    public List<BibEntry> parse(String text) throws IOException {
+        List<BibEntry> entries = new ArrayList<>();
+        BufferedReader reader = new BufferedReader(new StringReader(text));
+        String line;
+        StringBuilder current = null;
+        while ((line = reader.readLine()) != null) {
+            if (line.trim().startsWith("@")) {
+                if (current != null) {
+                    entries.add(parseEntry(current.toString()));
+                }
+                current = new StringBuilder();
+                current.append(line).append('\n');
+            } else if (current != null) {
+                current.append(line).append('\n');
+            }
+        }
+        if (current != null) {
+            entries.add(parseEntry(current.toString()));
+        }
+        return entries;
+    }
+
+    private BibEntry parseEntry(String entryText) {
+        BibEntry e = new BibEntry();
+        // typ jest przed klamrą np. @article{key,
+        int idx = entryText.indexOf('{');
+        if (idx > 1) {
+            e.setType(entryText.substring(1, idx).trim());
+        }
+        Pattern p = Pattern.compile("(\\w+)\\s*=\\s*[{\"](.*?)[}\"]", Pattern.DOTALL);
+        Matcher m = p.matcher(entryText);
+        while (m.find()) {
+            String key = m.group(1).toLowerCase();
+            String val = m.group(2).replaceAll("\n", " ").trim();
+            switch (key) {
+                case "title" -> e.setTitle(val);
+                case "author" -> e.setAuthors(val);
+                case "year" -> {
+                    try { e.setYear(Integer.parseInt(val)); } catch (NumberFormatException ignored) {}
+                }
+                case "journal" -> e.setJournal(val);
+                case "publisher" -> e.setJournal(val); // treat publisher same as journal field
+                case "doi" -> e.setDoi(val);
+            }
+        }
+        return e;
+    }
+
+    /**
+     * Generuje wyczyszczony BibTeX zawierający tylko wymagane pola.
+     */
+    public String cleanToBibtex(List<BibEntry> entries) {
+        StringBuilder sb = new StringBuilder();
+        for (BibEntry e : entries) {
+            sb.append(new BibTexService().toBibtex(e));
+        }
+        return sb.toString();
+    }
+}

--- a/server/src/main/java/com/bibengine/bibliography/BibTexController.java
+++ b/server/src/main/java/com/bibengine/bibliography/BibTexController.java
@@ -1,0 +1,37 @@
+package com.bibengine.bibliography;
+
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/bibtex")
+public class BibTexController {
+    private final BibTexCleanService cleanService;
+    private final LaTeXService laTeXService;
+
+    public BibTexController(BibTexCleanService cleanService, LaTeXService laTeXService) {
+        this.cleanService = cleanService;
+        this.laTeXService = laTeXService;
+    }
+
+    /**
+     * Zwraca wyczyszczony tekst BibTeX oraz \thebibliography na podstawie przesłanego pliku.
+     */
+    @PostMapping("/clean")
+    public Map<String, String> clean(@RequestParam("file") MultipartFile file) throws IOException {
+        String text = new String(file.getBytes(), StandardCharsets.UTF_8);
+        List<BibEntry> entries = cleanService.parse(text);
+        String cleaned = cleanService.cleanToBibtex(entries);
+        String latex = laTeXService.generateTheBibliography(entries);
+        Map<String, String> result = new HashMap<>();
+        result.put("bibtex", cleaned);
+        result.put("latex", latex);
+        return result;
+    }
+}

--- a/server/src/main/java/com/bibengine/bibliography/BibliographyController.java
+++ b/server/src/main/java/com/bibengine/bibliography/BibliographyController.java
@@ -2,7 +2,9 @@ package com.bibengine.bibliography;
 
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.data.domain.Sort;
 
+import java.util.Comparator;
 import java.util.List;
 
 /** Kontroler REST do zarządzania bazami bibliograficznymi */
@@ -23,8 +25,31 @@ public class BibliographyController {
     }
 
     @GetMapping
-    public List<Bibliography> myBibliographies(Authentication auth) {
-        return service.forUser(auth.getName());
+    public List<BibliographyDto> myBibliographies(Authentication auth,
+                                                 @RequestParam(required = false) String q,
+                                                 @RequestParam(required = false) String sort,
+                                                 @RequestParam(required = false) String dir) {
+        List<Bibliography> list = service.forUser(auth.getName());
+        if (q != null && !q.isBlank()) {
+            String ql = q.toLowerCase();
+            list = list.stream().filter(b ->
+                    (b.getName() != null && b.getName().toLowerCase().contains(ql)) ||
+                            (b.getComment() != null && b.getComment().toLowerCase().contains(ql))
+            ).toList();
+        }
+        if (sort != null) {
+            Comparator<Bibliography> c = switch (sort) {
+                case "comment" -> Comparator.comparing(Bibliography::getComment,
+                        Comparator.nullsLast(String::compareToIgnoreCase));
+                default -> Comparator.comparing(Bibliography::getName,
+                        Comparator.nullsLast(String::compareToIgnoreCase));
+            };
+            if ("desc".equalsIgnoreCase(dir)) c = c.reversed();
+            list = list.stream().sorted(c).toList();
+        }
+        return list.stream()
+                .map(b -> new BibliographyDto(b.getId(), b.getName(), b.getComment(), service.countEntries(b.getId())))
+                .toList();
     }
 
     @PostMapping
@@ -41,8 +66,26 @@ public class BibliographyController {
     }
 
     @GetMapping("/{id}/entries")
-    public List<BibEntry> listEntries(@PathVariable Long id) {
-        return service.get(id).map(Bibliography::getEntries).orElse(List.of());
+    public List<BibEntry> listEntries(@PathVariable Long id,
+                                      @RequestParam(required = false) String q,
+                                      @RequestParam(required = false) String sort,
+                                      @RequestParam(required = false) String dir) {
+        Sort s = Sort.unsorted();
+        if (sort != null) {
+            Sort.Direction d = "desc".equalsIgnoreCase(dir) ? Sort.Direction.DESC : Sort.Direction.ASC;
+            s = Sort.by(d, sort);
+        }
+        List<BibEntry> list = service.entries(id, s);
+        if (q != null && !q.isBlank()) {
+            String ql = q.toLowerCase();
+            list = list.stream().filter(e ->
+                    (e.getTitle() != null && e.getTitle().toLowerCase().contains(ql)) ||
+                            (e.getAuthors() != null && e.getAuthors().toLowerCase().contains(ql)) ||
+                            (e.getJournal() != null && e.getJournal().toLowerCase().contains(ql)) ||
+                            (e.getYear() != null && e.getYear().toString().contains(ql))
+            ).toList();
+        }
+        return list;
     }
 
     @GetMapping("/{id}/entries/by-doi")

--- a/server/src/main/java/com/bibengine/bibliography/BibliographyDto.java
+++ b/server/src/main/java/com/bibengine/bibliography/BibliographyDto.java
@@ -1,3 +1,3 @@
-package com.bibengine.web.dto;
+package com.bibengine.bibliography;
 
 public record BibliographyDto(Long id, String name, String comment, long entryCount) {}

--- a/server/src/main/java/com/bibengine/bibliography/BibliographyService.java
+++ b/server/src/main/java/com/bibengine/bibliography/BibliographyService.java
@@ -27,6 +27,14 @@ public class BibliographyService {
         return bibliographyRepository.findByOwner(user);
     }
 
+    public long countEntries(Long bibliographyId) {
+        return bibEntryRepository.countByBibliographyId(bibliographyId);
+    }
+
+    public List<BibEntry> entries(Long bibliographyId, org.springframework.data.domain.Sort sort) {
+        return bibEntryRepository.findByBibliographyId(bibliographyId, sort);
+    }
+
     @Transactional(readOnly = true)
     public Optional<Bibliography> get(Long id) {
         return bibliographyRepository.findById(id).map(b -> {


### PR DESCRIPTION
## Summary
- add DTO with entry count and new repository functions
- support searching and sorting in API
- display entry counts and filters in views
- new view to clean BibTeX file and get `\thebibliography`

## Testing
- `apt-get update -y`
- `apt-get install -y maven`
- `mvn -q -DskipTests install` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68440d761d74832c89c7e71f5fbabbc7