### PR TITLE
Add BibTeX cleaning tool and table features

### DIFF
--- a/client/src/main/java/com/bibengine/web/ToolsWebController.java
+++ b/client/src/main/java/com/bibengine/web/ToolsWebController.java
@@ -1,0 +1,58 @@
+package com.bibengine.web;
+
+import jakarta.servlet.http.HttpSession;
+import org.springframework.http.*;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Map;
+
+/** Widoki narzędziowe np. czyszczenie pliku BibTeX */
+@Controller
+@RequestMapping("/tools")
+public class ToolsWebController {
+    private final RestTemplate rest = new RestTemplate();
+
+    private HttpHeaders authHeaders(HttpSession session, MediaType type) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(type);
+        Object token = session.getAttribute("token");
+        if (token != null) {
+            headers.set(HttpHeaders.AUTHORIZATION, "Bearer " + token);
+        }
+        return headers;
+    }
+
+    @GetMapping("/clean-bibtex")
+    public String cleanForm() {
+        return "clean-bibtex";
+    }
+
+    @PostMapping(value = "/clean-bibtex")
+    public String clean(@RequestParam("file") MultipartFile file, Model model, HttpSession session) {
+        try {
+            ByteArrayResource resource = new ByteArrayResource(file.getBytes()) {
+                @Override
+                public String getFilename() { return file.getOriginalFilename(); }
+            };
+            MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+            body.add("file", resource);
+            HttpEntity<MultiValueMap<String, Object>> entity = new HttpEntity<>(body, authHeaders(session, MediaType.MULTIPART_FORM_DATA));
+            ResponseEntity<Map> resp = rest.exchange("http://localhost:5100/api/bibliography/clean", HttpMethod.POST, entity, Map.class);
+            model.addAttribute("bibtex", resp.getBody().get("bibtex"));
+            model.addAttribute("latex", resp.getBody().get("latex"));
+        } catch (Exception ex) {
+            model.addAttribute("error", "Nie udało się przetworzyć pliku");
+        }
+        return "clean-bibtex";
+    }
+}

--- a/client/src/main/java/com/bibengine/web/dto/BibliographyDto.java
+++ b/client/src/main/java/com/bibengine/web/dto/BibliographyDto.java
@@ -1,3 +1,3 @@
 package com.bibengine.web.dto;
 
-public record BibliographyDto(Long id, String name, String comment) {}
+public record BibliographyDto(Long id, String name, String comment, int entryCount) {}

--- a/client/src/main/resources/templates/bibliography.html
+++ b/client/src/main/resources/templates/bibliography.html
@@ -11,14 +11,16 @@
     <div class="container">
 <h1>Moje bibliografie</h1>
 <div class="alert alert-danger" th:if="${error}" th:text="${error}"></div>
-<table class="table">
+<input id="search" class="form-control mb-2" placeholder="Szukaj...">
+<table class="table" id="bibTable">
     <thead>
-    <tr><th>Nazwa</th><th>Notatka</th><th></th></tr>
+    <tr><th class="sortable">Nazwa</th><th class="sortable">Notatka</th><th class="sortable">Liczba wpisów</th><th></th></tr>
     </thead>
     <tbody>
     <tr th:each="b : ${bibliographies}">
         <td th:text="${b.name}"></td>
         <td th:text="${b.comment}"></td>
+        <td th:text="${b.entryCount}"></td>
         <td><a th:href="@{'/bibliography/' + ${b.id}}" class="btn btn-sm btn-primary">Wpisy</a></td>
     </tr>
     </tbody>
@@ -37,5 +39,30 @@
 </form>
     </div>
 </div>
+<script>
+    function sortTable(table, col, asc) {
+        const tbody = table.tBodies[0];
+        Array.from(tbody.querySelectorAll('tr'))
+            .sort((a,b)=>{
+                const t1=a.children[col].textContent.trim();
+                const t2=b.children[col].textContent.trim();
+                return asc ? t1.localeCompare(t2,'pl',{numeric:true}) : t2.localeCompare(t1,'pl',{numeric:true});
+            })
+            .forEach(tr=>tbody.appendChild(tr));
+    }
+    document.querySelectorAll('#bibTable th.sortable').forEach((th,i)=>{
+        th.addEventListener('click',()=>{
+            const asc=!th.classList.toggle('asc');
+            sortTable(th.closest('table'),i,asc);
+        });
+    });
+    document.getElementById('search').addEventListener('input',e=>{
+        const q=e.target.value.toLowerCase();
+        document.querySelectorAll('#bibTable tbody tr').forEach(tr=>{
+            const text=tr.textContent.toLowerCase();
+            tr.style.display=text.includes(q)?'':'none';
+        });
+    });
+</script>
 </body>
 </html>

--- a/client/src/main/resources/templates/clean-bibtex.html
+++ b/client/src/main/resources/templates/clean-bibtex.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Czyszczenie BibTeX - BibEngine</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" />
+</head>
+<body class="container">
+<h1>Czyszczenie pliku BibTeX</h1>
+<div class="alert alert-danger" th:if="${error}" th:text="${error}"></div>
+<form method="post" enctype="multipart/form-data" th:action="@{/tools/clean-bibtex}">
+    <div class="mb-3">
+        <input type="file" name="file" accept=".bib" class="form-control" required>
+    </div>
+    <button class="btn btn-primary">Wgraj i wyczyść</button>
+</form>
+<div class="mt-4" th:if="${bibtex}">
+    <h2>Wyczyszczony BibTeX</h2>
+    <textarea class="form-control" rows="10" readonly th:text="${bibtex}"></textarea>
+    <h2 class="mt-3">\thebibliography</h2>
+    <textarea class="form-control" rows="10" readonly th:text="${latex}"></textarea>
+</div>
+<p class="mt-3"><a th:href="@{/}" class="btn btn-link">Powrót</a></p>
+</body>
+</html>

--- a/client/src/main/resources/templates/entries.html
+++ b/client/src/main/resources/templates/entries.html
@@ -13,9 +13,10 @@
 <p th:text="${bibliography.comment}"></p>
 <div class="alert alert-danger" th:if="${error}" th:text="${error}"></div>
 <form method="post" th:action="@{'/bibliography/' + ${bibliography.id} + '/entries'}">
-<table class="table">
+<input id="search" class="form-control mb-2" placeholder="Szukaj...">
+<table class="table" id="entriesTable">
     <thead>
-    <tr><th>Tytuł</th><th>Autorzy</th><th>Rok</th><th>Journal</th><th>DOI</th><th>BibKey</th><th></th></tr>
+    <tr><th class="sortable">Tytuł</th><th class="sortable">Autorzy</th><th class="sortable">Rok</th><th class="sortable">Journal</th><th class="sortable">DOI</th><th class="sortable">BibKey</th><th></th></tr>
     <tr>
         <td><input class="form-control" name="title" required></td>
         <td><input class="form-control" name="authors" required></td>
@@ -73,5 +74,30 @@
 <p><a th:href="@{/bibliography}" class="btn btn-link">Powrót</a></p>
     </div>
 </div>
+<script>
+    function sortTable(table, col, asc) {
+        const tbody = table.tBodies[0];
+        Array.from(tbody.querySelectorAll('tr'))
+            .sort((a,b)=>{
+                const t1=a.children[col].textContent.trim();
+                const t2=b.children[col].textContent.trim();
+                return asc ? t1.localeCompare(t2,'pl',{numeric:true}) : t2.localeCompare(t1,'pl',{numeric:true});
+            })
+            .forEach(tr=>tbody.appendChild(tr));
+    }
+    document.querySelectorAll('#entriesTable th.sortable').forEach((th,i)=>{
+        th.addEventListener('click',()=>{
+            const asc=!th.classList.toggle('asc');
+            sortTable(th.closest('table'),i,asc);
+        });
+    });
+    document.getElementById('search').addEventListener('input',e=>{
+        const q=e.target.value.toLowerCase();
+        document.querySelectorAll('#entriesTable tbody tr').forEach(tr=>{
+            const text=tr.textContent.toLowerCase();
+            tr.style.display=text.includes(q)?'':'none';
+        });
+    });
+</script>
 </body>
 </html>

--- a/client/src/main/resources/templates/fragments/sidebar.html
+++ b/client/src/main/resources/templates/fragments/sidebar.html
@@ -5,6 +5,7 @@
             <li class="nav-item"><a th:href="@{/}" class="nav-link">Start</a></li>
             <li><a th:href="@{/bibliography}" class="nav-link">Bibliografie</a></li>
             <li><a th:href="@{/account}" class="nav-link">Konto</a></li>
+            <li><a th:href="@{/tools/clean-bibtex}" class="nav-link">Narzędzia</a></li>
             <li><a th:href="@{/docs}" class="nav-link">Dokumentacja</a></li>
             <li><a th:href="@{/regulamin}" class="nav-link">Regulamin</a></li>
         </ul>

--- a/server/src/main/java/com/bibengine/bibliography/BibEntryRepository.java
+++ b/server/src/main/java/com/bibengine/bibliography/BibEntryRepository.java
@@ -8,4 +8,6 @@ public interface BibEntryRepository extends JpaRepository<BibEntry, Long> {
     List<BibEntry> findByBibliographyOwnerId(Long ownerId);
 
     List<BibEntry> findByTitleContainingIgnoreCaseOrAuthorsContainingIgnoreCase(String title, String authors);
+
+    long countByBibliographyId(Long bibliographyId);
 }

--- a/server/src/main/java/com/bibengine/bibliography/BibliographyController.java
+++ b/server/src/main/java/com/bibengine/bibliography/BibliographyController.java
@@ -6,6 +6,7 @@ import org.springframework.http.MediaType;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+import java.util.Map;
 
 /** Kontroler REST do zarządzania bazami bibliograficznymi */
 @RestController
@@ -23,8 +24,12 @@ public class BibliographyController {
     }
 
     @GetMapping
-    public List<Bibliography> myBibliographies(Authentication auth) {
-        return service.forUser(auth.getName());
+    public List<BibliographyDto> myBibliographies(Authentication auth) {
+        return service.forUser(auth.getName()).stream()
+                .map(b -> new BibliographyDto(
+                        b.getId(), b.getName(), b.getComment(),
+                        service.countEntries(b.getId())))
+                .toList();
     }
 
     @PostMapping
@@ -64,7 +69,11 @@ public class BibliographyController {
     @PostMapping(path = "/{id}/entries/bibtex-file", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public List<BibEntry> addFromBibtexFile(@PathVariable Long id, @RequestParam("file") MultipartFile file) {
         try {
-            String text = new String(file.getBytes(), java.nio.charset.StandardCharsets.UTF_8);
+            byte[] bytes = file.getBytes();
+            String text = new String(bytes, java.nio.charset.StandardCharsets.UTF_8);
+            if (text.contains("�")) {
+                text = new String(bytes, java.nio.charset.Charset.forName("windows-1250"));
+            }
             var entries = bibTexService.fromBibtex(text);
             return service.addEntries(id, entries);
         } catch (java.io.IOException ex) {
@@ -97,6 +106,24 @@ public class BibliographyController {
     public String latex(@PathVariable Long id) {
         return service.get(id).map(b -> laTeXService.generateTheBibliography(b.getEntries()))
                 .orElse("");
+    }
+
+    /** Czyszczenie przesłanego pliku BibTeX i generowanie thebibliography */
+    @PostMapping(path = "/clean", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public java.util.Map<String, String> cleanBibtex(@RequestParam("file") MultipartFile file) {
+        try {
+            byte[] bytes = file.getBytes();
+            String text = new String(bytes, java.nio.charset.StandardCharsets.UTF_8);
+            if (text.contains("�")) {
+                text = new String(bytes, java.nio.charset.Charset.forName("windows-1250"));
+            }
+            var entries = bibTexService.fromBibtex(text);
+            String cleaned = entries.stream().map(bibTexService::toBibtex).reduce("", String::concat);
+            String latex = laTeXService.generateTheBibliography(entries);
+            return java.util.Map.of("bibtex", cleaned, "latex", latex);
+        } catch (java.io.IOException ex) {
+            throw new IllegalArgumentException("Nie udało się odczytać pliku");
+        }
     }
 
     @GetMapping("/entries/search")

--- a/server/src/main/java/com/bibengine/bibliography/BibliographyDto.java
+++ b/server/src/main/java/com/bibengine/bibliography/BibliographyDto.java
@@ -1,0 +1,4 @@
+package com.bibengine.bibliography;
+
+/** Prosty DTO z dodatkową informacją o liczbie wpisów */
+public record BibliographyDto(Long id, String name, String comment, int entryCount) {}

--- a/server/src/main/java/com/bibengine/bibliography/BibliographyService.java
+++ b/server/src/main/java/com/bibengine/bibliography/BibliographyService.java
@@ -44,6 +44,10 @@ public class BibliographyService {
 
     public void delete(Long id) { bibliographyRepository.deleteById(id); }
 
+    public int countEntries(Long bibliographyId) {
+        return (int) bibEntryRepository.countByBibliographyId(bibliographyId);
+    }
+
     public List<BibEntry> searchEntries(String username, String q) {
         // wyszukujemy wpisy użytkownika po tytule lub autorze
         User user = userRepository.findByUsername(username);


### PR DESCRIPTION
## Summary
- add entry count info from server
- fix encoding of uploaded BibTeX files
- implement BibTeX cleaning endpoint and view
- add search and sorting for tables
- expose tools link in sidebar

## Testing
- `mvn -q -pl server -DskipTests package` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68441070b51c832c8223d12989d053a9